### PR TITLE
Fix torrent protocol name

### DIFF
--- a/examples/unpackerr.conf.example
+++ b/examples/unpackerr.conf.example
@@ -50,8 +50,8 @@ parallel = 1
 #   api_key = "cb3afda6559445f1ae1d0299dd696e38"
    # File system path where downloaded Sonarr items are located.
 #   path = "/downloads"
-# Default protocols is torrents. Alternative: "torrents,usenet"
-#   protocols = "torrents"
+# Default protocols is torrents. Alternative: "torrent,usenet"
+#   protocols = "torrent"
 
 # Movies
 #[[radarr]]
@@ -59,8 +59,8 @@ parallel = 1
 #  api_key = "4bc34281deda4846a2fdab2c15bc8de8"
   # File system path where downloaded Radarr items are located.
 #  path = "/downloads"
-# Default protocols is torrents. Alternative: "torrents,usenet"
-#   protocols = "torrents"
+# Default protocols is torrents. Alternative: "torrent,usenet"
+#   protocols = "torrent"
 
 # Music
 #[[lidarr]]
@@ -68,8 +68,8 @@ parallel = 1
 #  api_key = "32454256defd484ab2fdab2c15bc17af"
   # File system path where downloaded Lidarr items are located.
 #  path = "/downloads"
-# Default protocols is torrents. Alternative: "torrents,usenet"
-#   protocols = "torrents"
+# Default protocols is torrents. Alternative: "torrent,usenet"
+#   protocols = "torrent"
 
 # Books
 #[[readarr]]
@@ -77,8 +77,8 @@ parallel = 1
 #  api_key = "123445defd484ab2fdab2c15babcd"
   # File system path where downloaded Lidarr items are located.
 #  path = "/downloads"
-# Default protocols is torrents. Alternative: "torrents,usenet"
-#   protocols = "torrents"
+# Default protocols is torrents. Alternative: "torrent,usenet"
+#   protocols = "torrent"
 
 # This application can also watch folders for things to extract. If you copy a
 # subfolder into a watched folder (defined below) any extractable items in the

--- a/examples/unpackerr.conf.example
+++ b/examples/unpackerr.conf.example
@@ -50,7 +50,7 @@ parallel = 1
 #   api_key = "cb3afda6559445f1ae1d0299dd696e38"
    # File system path where downloaded Sonarr items are located.
 #   path = "/downloads"
-# Default protocols is torrents. Alternative: "torrent,usenet"
+# Default protocols is torrent. Alternative: "torrent,usenet"
 #   protocols = "torrent"
 
 # Movies

--- a/examples/unpackerr.conf.example
+++ b/examples/unpackerr.conf.example
@@ -68,7 +68,7 @@ parallel = 1
 #  api_key = "32454256defd484ab2fdab2c15bc17af"
   # File system path where downloaded Lidarr items are located.
 #  path = "/downloads"
-# Default protocols is torrents. Alternative: "torrent,usenet"
+# Default protocols is torrent. Alternative: "torrent,usenet"
 #   protocols = "torrent"
 
 # Books

--- a/examples/unpackerr.conf.example
+++ b/examples/unpackerr.conf.example
@@ -77,7 +77,7 @@ parallel = 1
 #  api_key = "123445defd484ab2fdab2c15babcd"
   # File system path where downloaded Lidarr items are located.
 #  path = "/downloads"
-# Default protocols is torrents. Alternative: "torrent,usenet"
+# Default protocols is torrent. Alternative: "torrent,usenet"
 #   protocols = "torrent"
 
 # This application can also watch folders for things to extract. If you copy a


### PR DESCRIPTION
Fixing the torrent protocol name in the example config file.

After spending quite some time debugging why it wasn't picking up the files to extract that small was the culprit, I had that file copy and pasted.