### PR TITLE
Fix bugs with windows+folders. Add unpackerr user/group and webhook test

### DIFF
--- a/examples/MANUAL.md
+++ b/examples/MANUAL.md
@@ -26,6 +26,11 @@ OPTIONS
         This application parses environment variables into config data.
         The default prefix is UN, making env variables like UN_SONARR_URL.
 
+    -w, --webhook <1,2,3,4,5,6,7,8>
+        This sends a webhook of the type specified then exits. This is only
+        for testing and development. This requires a valid webhook configured
+        in a config file or from environment variables.
+
     -v, --version
         Display version and exit.
 

--- a/init/systemd/template.unit.service
+++ b/init/systemd/template.unit.service
@@ -17,7 +17,11 @@ StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier={{BINARY}}
 Type=simple
-User=nobody
+
+# These should be set correctly for your environment.
+UMask=0002
+User={{BINARY}}
+Group={{BINARY}}
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/unpackerr/folder.go
+++ b/pkg/unpackerr/folder.go
@@ -5,7 +5,7 @@ package unpackerr
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -226,12 +226,12 @@ func (f *Folders) watchFSNotify() {
 				// event.Name: "/Users/Documents/auto/my_folder/file.rar"
 				// p: "my_folder"
 				p := strings.TrimPrefix(event.Name, cnfg.Path)
-				if np := path.Dir(p); np != "." {
+				if np := filepath.Dir(p); np != "." {
 					p = np
 				}
 
 				// Send this event to processEvent().
-				f.Events <- &eventData{name: p, cnfg: cnfg, file: path.Base(event.Name)}
+				f.Events <- &eventData{name: p, cnfg: cnfg, file: filepath.Base(event.Name)}
 			}
 		}
 	}
@@ -239,7 +239,7 @@ func (f *Folders) watchFSNotify() {
 
 // processEvent processes the event that was received.
 func (f *Folders) processEvent(event *eventData) {
-	fullPath := path.Join(event.cnfg.Path, event.name)
+	fullPath := filepath.Join(event.cnfg.Path, event.name)
 	if stat, err := os.Stat(fullPath); err != nil {
 		// Item is unusable (probably deleted), remove it from history.
 		if _, ok := f.Folders[fullPath]; ok {

--- a/pkg/unpackerr/start.go
+++ b/pkg/unpackerr/start.go
@@ -49,6 +49,7 @@ type Flags struct {
 	verReq     bool
 	ConfigFile string
 	EnvPrefix  string
+	webhook    uint
 }
 
 // History holds the history of extracted items.
@@ -102,6 +103,11 @@ func Start() (err error) {
 
 	fm, dm := u.validateConfig()
 	u.Logf("Unpackerr v%s Starting! (PID: %v) %v", version.Version, os.Getpid(), time.Now())
+
+	if u.Flags.webhook > 0 {
+		return u.sampleWebhook(ExtractStatus(u.Flags.webhook))
+	}
+
 	u.logStartupInfo()
 
 	u.Xtractr = xtractr.NewQueue(&xtractr.Config{
@@ -129,6 +135,7 @@ func (u *Unpackerr) ParseFlags() *Unpackerr {
 
 	flag.StringVarP(&u.Flags.ConfigFile, "config", "c", defaultConfFile, "Poller Config File (TOML Format)")
 	flag.StringVarP(&u.Flags.EnvPrefix, "prefix", "p", "UN", "Environment Variable Prefix")
+	flag.UintVarP(&u.Flags.webhook, "webhook", "w", 0, "Send test webhook. Valid values: 1,2,3,4,5,6,7,8")
 	flag.BoolVarP(&u.Flags.verReq, "version", "v", false, "Print the version and exit.")
 	flag.Parse()
 

--- a/pkg/unpackerr/webhook_samples.go
+++ b/pkg/unpackerr/webhook_samples.go
@@ -54,6 +54,10 @@ func (u *Unpackerr) sampleWebhook(e ExtractStatus) error {
 		payload.App = "Folder"
 	}
 
+	if e == EXTRACTFAILED {
+		payload.Resp.Error = xtractr.ErrInvalidHead
+	}
+
 	for _, hook := range u.Webhook {
 		u.sendWebhookWithLog(hook, payload)
 	}

--- a/pkg/unpackerr/webhook_samples.go
+++ b/pkg/unpackerr/webhook_samples.go
@@ -1,0 +1,62 @@
+package unpackerr
+
+import (
+	"time"
+
+	"golift.io/version"
+	"golift.io/xtractr"
+)
+
+func (u *Unpackerr) sampleWebhook(e ExtractStatus) error {
+	u.Logf("Sending webhooks.")
+
+	if e == WAITING || e > DELETED {
+		return ErrInvalidStatus
+	}
+
+	payload := &Extract{
+		App:  Sonarr,
+		Path: "/this/is/the/extraction/path",
+		IDs: map[string]interface{}{
+			"downloadId": "some-id-goes-here",
+			"otherId":    "another-id-here-like-imdb",
+		},
+		Status:  e,
+		Updated: time.Now(),
+		Resp: &xtractr.Response{
+			Elapsed:  time.Since(version.Started),
+			Extras:   nil,
+			Archives: []string{"/this/is/the/extraction/path/archive.rar"},
+			AllFiles: nil,
+			Error:    nil,
+			X: &xtractr.Xtract{
+				Name:       "path",
+				SearchPath: "/this/is/the/extraction/path",
+				TempFolder: true,
+				DeleteOrig: false,
+				CBFunction: nil,
+				CBChannel:  nil,
+			},
+			Started:  version.Started,
+			Done:     e >= EXTRACTED,
+			Output:   "/this/is/the/extraction/path_unpackerred",
+			Queued:   0,
+			NewFiles: nil,
+			Size:     0,
+		},
+	}
+
+	if e != EXTRACTING && e != EXTRACTED && e != EXTRACTFAILED {
+		payload.Resp = nil
+	}
+
+	if e == QUEUED {
+		payload.App = "Folder"
+	}
+
+	for _, hook := range u.Webhook {
+		u.sendWebhookWithLog(hook, payload)
+	}
+
+	return nil
+}

--- a/scripts/after-install.sh
+++ b/scripts/after-install.sh
@@ -3,6 +3,9 @@
 # This file is used by deb and rpm packages.
 # FPM adds this as the after-install script.
 
+# Make a user and group for this app.
+useradd --system --user-group --no-create-home --home-dir /tmp --shell /bin/false unpackerr
+
 if [ -x "/bin/systemctl" ]; then
   # Reload and restart - this starts the application as user nobody.
   /bin/systemctl daemon-reload


### PR DESCRIPTION
- Fixes some bugs encountered when trying to use the `folder` feature on Windows. Seems to work now!
- Adds an `unpackerr` user and group to linux packages. Adds `UMask` option too, defaulted to group writable.
  - To use this on Linux, add your other apps to the `unpackerr` group.
  - Add `Sonarr` user to `unpackerr` group like this: `usermod -G unpackerr sonarr`
- Adds code to provide sending fake Webhooks [for testing and development].