### PR TITLE
Fix log rotation

### DIFF
--- a/pkg/unpackerr/logs.go
+++ b/pkg/unpackerr/logs.go
@@ -77,18 +77,27 @@ func (status ExtractStatus) String() string {
 // Debugf writes Debug log lines... to stdout and/or a file.
 func (l *Logger) Debugf(msg string, v ...interface{}) {
 	if l.debug {
-		_ = l.Logger.Output(callDepth, "[DEBUG] "+fmt.Sprintf(msg, v...))
+		err := l.Logger.Output(callDepth, "[DEBUG] "+fmt.Sprintf(msg, v...))
+		if err != nil {
+			fmt.Println("Logger Error:", err)
+		}
 	}
 }
 
 // Print writes log lines... to stdout and/or a file.
 func (l *Logger) Print(v ...interface{}) {
-	_ = l.Logger.Output(callDepth, fmt.Sprintln(v...))
+	err := l.Logger.Output(callDepth, fmt.Sprintln(v...))
+	if err != nil {
+		fmt.Println("Logger Error:", err)
+	}
 }
 
 // Printf writes log lines... to stdout and/or a file.
 func (l *Logger) Printf(msg string, v ...interface{}) {
-	_ = l.Logger.Output(callDepth, fmt.Sprintf(msg, v...))
+	err := l.Logger.Output(callDepth, fmt.Sprintf(msg, v...))
+	if err != nil {
+		fmt.Println("Logger Error:", err)
+	}
 }
 
 // logCurrentQueue prints the number of things happening.
@@ -137,7 +146,7 @@ func (u *Unpackerr) setupLogging() {
 		u.Logger.Logger.SetFlags(log.Lshortfile | log.Lmicroseconds | log.Ldate)
 	}
 
-	switch { // only use MultiWriter is we have > 1 writer.
+	switch { // only use MultiWriter if we have > 1 writer.
 	case !u.Config.Quiet && u.Config.LogFile != "":
 		u.Logger.Logger.SetOutput(io.MultiWriter(&lumberjack.Logger{
 			Filename:   u.Config.LogFile,   // log file name.
@@ -165,6 +174,7 @@ func (u *Unpackerr) setupLogging() {
 
 // logStartupInfo prints info about our startup config.
 func (u *Unpackerr) logStartupInfo() {
+	u.Printf("==> %s <==", helpLink)
 	u.Print("==> Startup Settings <==")
 	u.logSonarr()
 	u.logRadarr()

--- a/pkg/unpackerr/start.go
+++ b/pkg/unpackerr/start.go
@@ -109,6 +109,7 @@ func Start() (err error) {
 
 	fm, dm := u.validateConfig()
 	// Do not do any logging before this.
+	// ie. No running of u.Debugf or u.Print* before running validateConfig()
 
 	if u.Flags.webhook > 0 {
 		return u.sampleWebhook(ExtractStatus(u.Flags.webhook))
@@ -126,7 +127,7 @@ func Start() (err error) {
 
 	go u.Run()
 	signal.Notify(u.sigChan, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT)
-	u.Printf("=====> Need help? %s\n=====> Exiting! Caught Signal: %v", helpLink, <-u.sigChan)
+	u.Printf("[unpackerr] Need help? %s\n=====> Exiting! Caught Signal: %v", helpLink, <-u.sigChan)
 
 	return nil
 }


### PR DESCRIPTION
This contribution fixes the initialization and use of the internal Logger interface. Basically, it was being initialized out of order and passing in default values to `lumberjack` and the rest of the logging piece. whoops. This corrects that mistake so log rotation works as configured.

This also exposes any log-write errors to the console. They were being hidden previously. Also adds a link to discord.