### PR TITLE
Add two new features involving file deletion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ log_files|`UN_LOG_FILES`|`10` / Log files to keep after rotating. `0` disables r
 log_file_mb|`UN_LOG_FILE_MB`|`10` / Max size of log files in megabytes|
 interval|`UN_INTERVAL`|`2m` / How often apps are polled, recommend `1m` to `5m`|
 timeout|`UN_TIMEOUT`|`10s` / Global API Timeouts (all apps default)|
-delete_delay|`UN_DELETE_DELAY`|`5m` / Extracts are deleted this long after import|
+delete_orig|`UN_DELETE_ORIG`|`false` / Delete archives? Recommend not setting this to true|
+delete_delay|`UN_DELETE_DELAY`|`5m` / Extracts are deleted this long after import, `-1` to disable|
 start_delay|`UN_START_DELAY`|`1m` / Files are queued at least this long before extraction|
 retry_delay|`UN_RETRY_DELAY`|`5m` / Failed extractions are retried after at least this long|
 max_retries|`UN_MAX_RETRIES`|`3` / Times to retry failed extractions. `0` = unlimited.|

--- a/README.md
+++ b/README.md
@@ -62,9 +62,6 @@ log_file|`UN_LOG_FILE`|None by default. Optionally provide a file path to write 
 log_files|`UN_LOG_FILES`|`10` / Log files to keep after rotating. `0` disables rotation|
 log_file_mb|`UN_LOG_FILE_MB`|`10` / Max size of log files in megabytes|
 interval|`UN_INTERVAL`|`2m` / How often apps are polled, recommend `1m` to `5m`|
-timeout|`UN_TIMEOUT`|`10s` / Global API Timeouts (all apps default)|
-delete_orig|`UN_DELETE_ORIG`|`false` / Delete archives? Recommend not setting this to true|
-delete_delay|`UN_DELETE_DELAY`|`5m` / Extracts are deleted this long after import, `-1` to disable|
 start_delay|`UN_START_DELAY`|`1m` / Files are queued at least this long before extraction|
 retry_delay|`UN_RETRY_DELAY`|`5m` / Failed extractions are retried after at least this long|
 max_retries|`UN_MAX_RETRIES`|`3` / Times to retry failed extractions. `0` = unlimited.|
@@ -80,6 +77,9 @@ sonarr.url|`UN_SONARR_0_URL`|No Default. Something like: `http://localhost:8989`
 sonarr.api_key|`UN_SONARR_0_API_KEY`|No Default. Provide URL and API key if you use Sonarr|
 sonarr.paths|`UN_SONARR_0_PATHS_0`|`/downloads` List of paths where content is downloaded for Sonarr|
 sonarr.protocols|`UN_SONARR_0_PROTOCOLS`|`torrent` Protocols to process. Alt: `torrent,usenet`|
+sonarr.timeout|`UN_SONARR_0_TIMEOUT`|`10s` / How long to wait for the app to respond|
+sonarr.delete_orig|`UN_SONARR_0_DELETE_ORIG`|`false` / Delete archives? Recommend not setting this to true|
+sonarr.delete_delay|`UN_SONARR_0_DELETE_DELAY`|`5m` / Extracts are deleted this long after import, `-1` to disable|
 
 ##### Radarr
 
@@ -89,6 +89,9 @@ radarr.url|`UN_RADARR_0_URL`|No Default. Something like: `http://localhost:7878`
 radarr.api_key|`UN_RADARR_0_API_KEY`|No Default. Provide URL and API key if you use Radarr|
 radarr.paths|`UN_RADARR_0_PATHS_0`|`/downloads` List of paths where content is downloaded for Radarr|
 radarr.protocols|`UN_RADARR_0_PROTOCOLS`|`torrent` Protocols to process. Alt: `torrent,usenet`|
+radarr.timeout|`UN_RADARR_0_TIMEOUT`|`10s` / How long to wait for the app to respond|
+radarr.delete_orig|`UN_RADARR_0_DELETE_ORIG`|`false` / Delete archives? Recommend not setting this to true|
+radarr.delete_delay|`UN_RADARR_0_DELETE_DELAY`|`5m` / Extracts are deleted this long after import, `-1` to disable|
 
 ##### Lidarr
 
@@ -98,6 +101,9 @@ lidarr.url|`UN_LIDARR_0_URL`|No Default. Something like: `http://localhost:8686`
 lidarr.api_key|`UN_LIDARR_0_API_KEY`|No Default. Provide URL and API key if you use Lidarr|
 lidarr.paths|`UN_LIDARR_0_PATHS_0`|`/downloads` List of paths where content is downloaded for Lidarr|
 lidarr.protocols|`UN_LIDARR_0_PROTOCOLS`|`torrent` Protocols to process. Alt: `torrent,usenet`|
+lidarr.timeout|`UN_LIDARR_0_TIMEOUT`|`10s` / How long to wait for the app to respond|
+lidarr.delete_orig|`UN_LIDARR_0_DELETE_ORIG`|`false` / Delete archives? Recommend not setting this to true|
+lidarr.delete_delay|`UN_LIDARR_0_DELETE_DELAY`|`5m` / Extracts are deleted this long after import, `-1` to disable|
 
 ##### Readarr
 
@@ -107,6 +113,9 @@ readarr.url|`UN_READARR_0_URL`|No Default. Something like: `http://localhost:878
 readarr.api_key|`UN_READARR_0_API_KEY`|No Default. Provide URL and API key if you use Readarr|
 readarr.paths|`UN_READARR_0_PATHS_0`|`/downloads` List of paths where content is downloaded for Readarr|
 readarr.protocols|`UN_READARR_0_PROTOCOLS`|`torrent` Protocols to process. Alt: `torrent,usenet`|
+readarr.timeout|`UN_READARR_0_TIMEOUT`|`10s` / How long to wait for the app to respond|
+readarr.delete_orig|`UN_READARR_0_DELETE_ORIG`|`false` / Delete archives? Recommend not setting this to true|
+readarr.delete_delay|`UN_READARR_0_DELETE_DELAY`|`5m` / Extracts are deleted this long after import, `-1` to disable|
 
 ##### Folder
 

--- a/examples/unpackerr.conf.example
+++ b/examples/unpackerr.conf.example
@@ -31,7 +31,13 @@ timeout = "10s"
 # How long ago a file must have been imported before deletion. The file must
 # also not be part of an active queue item. Set this to "1m" to make sure files
 # are deleted quickly after being imported. Recommend "5m". Uses Go Duration.
+# Setting this to any negative number `-1` disables deleting extracted files.
 delete_delay = "5m"
+
+# If you use this app with NZB you may wish to delete archives after extraction.
+# General recommendation is: do not enable this for torrent use.
+# `delete_delay` does not affect this setting.
+delete_orig = false
 
 # How long an item must be queued (download complete) before extraction will start.
 # One minute is the historic default and works well. Set higher if your downloads

--- a/examples/unpackerr.conf.example
+++ b/examples/unpackerr.conf.example
@@ -24,21 +24,6 @@ log_file_mb = 10
 # Recommend 1m-5m. Uses Go Duration.
 interval = "2m"
 
-# How long to wait for a reply from the backends: Sonarr, Radarr, Lidarr.
-# This can also be set per-app. Uses Go Duration.
-timeout = "10s"
-
-# How long ago a file must have been imported before deletion. The file must
-# also not be part of an active queue item. Set this to "1m" to make sure files
-# are deleted quickly after being imported. Recommend "5m". Uses Go Duration.
-# Setting this to any negative number `-1` disables deleting extracted files.
-delete_delay = "5m"
-
-# If you use this app with NZB you may wish to delete archives after extraction.
-# General recommendation is: do not enable this for torrent use.
-# `delete_delay` does not affect this setting.
-delete_orig = false
-
 # How long an item must be queued (download complete) before extraction will start.
 # One minute is the historic default and works well. Set higher if your downloads
 # take longer to finalize (or transfer locally). Uses Go Duration.
@@ -77,7 +62,6 @@ dir_mode = "0755"
 #  events     = [0]   # list of event ids to include, 0 == all.
 #  exclude    = []    # list of apps to exclude, ie. ["radarr", "lidarr"]
 
-
 ################
 ### Episodes ###
 ################
@@ -88,6 +72,17 @@ dir_mode = "0755"
 #  paths = ["/downloads"]
 ## Default protocols is torrent. Alternative: "torrent,usenet"
 #  protocols = "torrent"
+## How long to wait for a reply from the backend.
+#  timeout = "10s"
+## How long ago a file must have been imported before deletion. The file must
+## also not be part of an active queue item. Set this to "1m" to make sure files
+## are deleted quickly after being imported. Recommend "5m". Uses Go Duration.
+## Setting this to any negative number `-1` disables deleting extracted files.
+#  delete_delay = "5m"
+## If you use this app with NZB you may wish to delete archives after extraction.
+## General recommendation is: do not enable this for torrent use.
+## This setting is not affected by `delete_delay`.
+#  delete_orig = false
 
 ################
 #### Movies ####
@@ -99,6 +94,17 @@ dir_mode = "0755"
 #  paths = ["/downloads"]
 ## Default protocols is torrents. Alternative: "torrent,usenet"
 #  protocols = "torrent"
+## How long to wait for a reply from the backend.
+#  timeout = "10s"
+## How long ago a file must have been imported before deletion. The file must
+## also not be part of an active queue item. Set this to "1m" to make sure files
+## are deleted quickly after being imported. Recommend "5m". Uses Go Duration.
+## Setting this to any negative number `-1` disables deleting extracted files.
+#  delete_delay = "5m"
+## If you use this app with NZB you may wish to delete archives after extraction.
+## General recommendation is: do not enable this for torrent use.
+## This setting is not affected by `delete_delay`.
+#  delete_orig = false
 
 ################
 #### Albums ####
@@ -110,6 +116,17 @@ dir_mode = "0755"
 #  paths = ["/downloads"]
 ## Default protocols is torrent. Alternative: "torrent,usenet"
 #  protocols = "torrent"
+## How long to wait for a reply from the backend.
+#  timeout = "10s"
+## How long ago a file must have been imported before deletion. The file must
+## also not be part of an active queue item. Set this to "1m" to make sure files
+## are deleted quickly after being imported. Recommend "5m". Uses Go Duration.
+## Setting this to any negative number `-1` disables deleting extracted files.
+#  delete_delay = "5m"
+## If you use this app with NZB you may wish to delete archives after extraction.
+## General recommendation is: do not enable this for torrent use.
+## This setting is not affected by `delete_delay`.
+#  delete_orig = false
 
 ################
 # Publications #
@@ -121,6 +138,17 @@ dir_mode = "0755"
 #  paths = ["/downloads"]
 ## Default protocols is torrent. Alternative: "torrent,usenet"
 #  protocols = "torrent"
+## How long to wait for a reply from the backend.
+#  timeout = "10s"
+## How long ago a file must have been imported before deletion. The file must
+## also not be part of an active queue item. Set this to "1m" to make sure files
+## are deleted quickly after being imported. Recommend "5m". Uses Go Duration.
+## Setting this to any negative number `-1` disables deleting extracted files.
+#  delete_delay = "5m"
+## If you use this app with NZB you may wish to delete archives after extraction.
+## General recommendation is: do not enable this for torrent use.
+## This setting is not affected by `delete_delay`.
+#  delete_orig = false
 
 ##-Folders-####################################################################
 ## This application can also watch folders for things to extract. If you copy a

--- a/pkg/unpackerr/apps.go
+++ b/pkg/unpackerr/apps.go
@@ -36,6 +36,7 @@ const (
 type Config struct {
 	Debug       bool             `json:"debug" toml:"debug" xml:"debug" yaml:"debug"`
 	Quiet       bool             `json:"quiet" toml:"quiet" xml:"quiet" yaml:"quiet"`
+	DeleteOrig  bool             `json:"delete_orig" toml:"delete_orig" xml:"delete_orig" yaml:"delete_orig"`
 	Parallel    uint             `json:"parallel" toml:"parallel" xml:"parallel" yaml:"parallel"`
 	LogFile     string           `json:"log_file" toml:"log_file" xml:"log_file" yaml:"log_file"`
 	LogFiles    int              `json:"log_files" toml:"log_files" xml:"log_files" yaml:"log_files"`

--- a/pkg/unpackerr/handlers.go
+++ b/pkg/unpackerr/handlers.go
@@ -97,7 +97,7 @@ func (u *Unpackerr) handleCompletedDownload(name, app, path string, ids map[stri
 		Name:       name,
 		SearchPath: path,
 		TempFolder: false,
-		DeleteOrig: false,
+		DeleteOrig: u.DeleteOrig,
 		CBChannel:  u.updates,
 	})
 	u.Printf("[%s] Extraction Queued: %s, extractable files: %d, items in queue: %d", app, path, len(files), queueSize)
@@ -125,7 +125,7 @@ func (u *Unpackerr) checkExtractDone() {
 			u.Printf("[%s] Extract failed %v ago, triggering restart (%d/%d): %v",
 				data.App, elapsed.Round(time.Second), data.Retries, u.MaxRetries, name)
 		case data.Status == IMPORTED && elapsed >= u.DeleteDelay.Duration:
-			if len(data.Resp.NewFiles) > 0 {
+			if len(data.Resp.NewFiles) > 0 && u.DeleteDelay.Duration > 0 {
 				// In a routine so it can run slowly and not block.
 				go u.DeleteFiles(data.Resp.NewFiles...)
 			}

--- a/pkg/unpackerr/handlers.go
+++ b/pkg/unpackerr/handlers.go
@@ -12,13 +12,15 @@ import (
 
 // Extract holds data for files being extracted.
 type Extract struct {
-	Path    string
-	App     string
-	IDs     map[string]interface{}
-	Status  ExtractStatus
-	Updated time.Time
-	Resp    *xtractr.Response
-	Retries uint
+	Retries     uint
+	Path        string
+	App         string
+	Updated     time.Time
+	DeleteDelay time.Duration
+	DeleteOrig  bool
+	Status      ExtractStatus
+	IDs         map[string]interface{}
+	Resp        *xtractr.Response
 }
 
 // checkQueueChanges checks each item for state changes from the app queues.
@@ -38,10 +40,10 @@ func (u *Unpackerr) checkQueueChanges() {
 				u.Debugf("Already imported? %s", name)
 			case data.Status == IMPORTED:
 				u.Debugf("%v: Awaiting Delete Delay (%v remains): %v",
-					data.App, u.DeleteDelay.Duration-elapsed.Round(time.Second), name)
+					data.App, data.DeleteDelay-elapsed.Round(time.Second), name)
 			default:
 				u.updateQueueStatus(&newStatus{Name: name, Status: IMPORTED, Resp: data.Resp})
-				u.Printf("[%v] Imported: %v (delete in %v)", data.App, name, u.DeleteDelay)
+				u.Printf("[%v] Imported: %v (delete in %v)", data.App, name, data.DeleteDelay)
 			}
 		case data.Status == IMPORTED:
 			// The item fell out of the app queue and came back. Reset it.
@@ -61,31 +63,33 @@ func (u *Unpackerr) checkQueueChanges() {
 
 // handleCompletedDownload checks if a sonarr/radarr/lidar completed item needs to be extracted.
 // This is called from the app methods.
-func (u *Unpackerr) handleCompletedDownload(name, app, path string, ids map[string]interface{}) {
+func (u *Unpackerr) handleCompletedDownload(name string, x *Extract) {
 	item, ok := u.Map[name]
 	if !ok {
 		u.Map[name] = &Extract{
-			App:     app,
-			Path:    path,
-			IDs:     ids,
-			Status:  WAITING,
-			Updated: time.Now(),
+			App:         x.App,
+			Path:        x.Path,
+			IDs:         x.IDs,
+			DeleteOrig:  x.DeleteOrig,
+			DeleteDelay: x.DeleteDelay,
+			Status:      WAITING,
+			Updated:     time.Now(),
 		}
 		item = u.Map[name]
 	}
 
 	if time.Since(item.Updated) < u.Config.StartDelay.Duration {
-		u.Printf("[%s] Waiting for Start Delay: %v (%v remains)", app, name,
+		u.Printf("[%s] Waiting for Start Delay: %v (%v remains)", x.App, name,
 			u.Config.StartDelay.Duration-time.Since(item.Updated).Round(time.Second))
 
 		return
 	}
 
-	files := xtractr.FindCompressedFiles(path)
+	files := xtractr.FindCompressedFiles(x.Path)
 	if len(files) == 0 {
-		_, err := os.Stat(path)
+		_, err := os.Stat(x.Path)
 		u.Printf("[%s] Completed item still waiting: %s, no extractable files found at: %s (stat err: %v)",
-			app, name, path, err)
+			x.App, name, x.Path, err)
 
 		return
 	}
@@ -95,12 +99,12 @@ func (u *Unpackerr) handleCompletedDownload(name, app, path string, ids map[stri
 
 	queueSize, _ := u.Extract(&xtractr.Xtract{
 		Name:       name,
-		SearchPath: path,
+		SearchPath: x.Path,
 		TempFolder: false,
-		DeleteOrig: u.DeleteOrig,
+		DeleteOrig: x.DeleteOrig,
 		CBChannel:  u.updates,
 	})
-	u.Printf("[%s] Extraction Queued: %s, extractable files: %d, items in queue: %d", app, path, len(files), queueSize)
+	u.Printf("[%s] Extraction Queued: %s, extractable files: %d, items in queue: %d", x.App, x.Path, len(files), queueSize)
 }
 
 // checkExtractDone checks if an extracted item imported items needs to be deleted.
@@ -109,7 +113,7 @@ func (u *Unpackerr) handleCompletedDownload(name, app, path string, ids map[stri
 func (u *Unpackerr) checkExtractDone() {
 	for name, data := range u.Map {
 		switch elapsed := time.Since(data.Updated); {
-		case data.Status == DELETED && elapsed >= u.DeleteDelay.Duration:
+		case data.Status == DELETED && elapsed >= data.DeleteDelay:
 			// Remove the item from history some time after it's deleted.
 			u.Finished++
 			delete(u.Map, name)
@@ -124,8 +128,8 @@ func (u *Unpackerr) checkExtractDone() {
 			data.Updated = time.Now()
 			u.Printf("[%s] Extract failed %v ago, triggering restart (%d/%d): %v",
 				data.App, elapsed.Round(time.Second), data.Retries, u.MaxRetries, name)
-		case data.Status == IMPORTED && elapsed >= u.DeleteDelay.Duration:
-			if len(data.Resp.NewFiles) > 0 && u.DeleteDelay.Duration > 0 {
+		case data.Status == IMPORTED && elapsed >= data.DeleteDelay:
+			if len(data.Resp.NewFiles) > 0 && data.DeleteDelay >= 0 {
 				// In a routine so it can run slowly and not block.
 				go u.DeleteFiles(data.Resp.NewFiles...)
 			}

--- a/pkg/unpackerr/radarr.go
+++ b/pkg/unpackerr/radarr.go
@@ -3,6 +3,7 @@ package unpackerr
 import (
 	"sync"
 
+	"golift.io/cnfg"
 	"golift.io/starr"
 	"golift.io/starr/radarr"
 )
@@ -13,6 +14,8 @@ type RadarrConfig struct {
 	Path           string          `json:"path" toml:"path" xml:"path" yaml:"path"`
 	Paths          []string        `json:"paths" toml:"paths" xml:"paths" yaml:"paths"`
 	Protocols      string          `json:"protocols" toml:"protocols" xml:"protocols" yaml:"protocols"`
+	DeleteOrig     bool            `json:"delete_orig" toml:"delete_orig" xml:"delete_orig" yaml:"delete_orig"`
+	DeleteDelay    cnfg.Duration   `json:"delete_delay" toml:"delete_delay" xml:"delete_delay" yaml:"delete_delay"`
 	Queue          []*radarr.Queue `json:"-" toml:"-" xml:"-" yaml:"-"`
 	sync.RWMutex   `json:"-" toml:"-" xml:"-" yaml:"-"`
 	*radarr.Radarr `json:"-" toml:"-" xml:"-" yaml:"-"`
@@ -22,6 +25,10 @@ func (u *Unpackerr) validateRadarr() {
 	for i := range u.Radarr {
 		if u.Radarr[i].Timeout.Duration == 0 {
 			u.Radarr[i].Timeout.Duration = u.Timeout.Duration
+		}
+
+		if u.Radarr[i].DeleteDelay.Duration == 0 {
+			u.Radarr[i].DeleteDelay.Duration = u.DeleteDelay.Duration
 		}
 
 		if u.Radarr[i].Path != "" {
@@ -85,8 +92,13 @@ func (u *Unpackerr) checkRadarrQueue() {
 			case ok && x.Status == EXTRACTED && u.isComplete(q.Status, q.Protocol, server.Protocols):
 				u.Debugf("%s (%s): Item Waiting for Import (%s): %v", Radarr, server.URL, q.Protocol, q.Title)
 			case (!ok || x.Status < QUEUED) && u.isComplete(q.Status, q.Protocol, server.Protocols):
-				u.handleCompletedDownload(q.Title, Radarr, u.getDownloadPath(q.StatusMessages, Radarr, q.Title, server.Paths),
-					map[string]interface{}{"tmdbId": q.Movie.TmdbID, "imdbId": q.Movie.ImdbID, "downloadId": q.DownloadID})
+				u.handleCompletedDownload(q.Title, &Extract{
+					App:         Radarr,
+					DeleteOrig:  server.DeleteOrig,
+					DeleteDelay: server.DeleteDelay.Duration,
+					Path:        u.getDownloadPath(q.StatusMessages, Radarr, q.Title, server.Paths),
+					IDs:         map[string]interface{}{"tmdbId": q.Movie.TmdbID, "imdbId": q.Movie.ImdbID, "downloadId": q.DownloadID},
+				})
 
 				fallthrough
 			default:

--- a/pkg/unpackerr/radarr.go
+++ b/pkg/unpackerr/radarr.go
@@ -97,7 +97,11 @@ func (u *Unpackerr) checkRadarrQueue() {
 					DeleteOrig:  server.DeleteOrig,
 					DeleteDelay: server.DeleteDelay.Duration,
 					Path:        u.getDownloadPath(q.StatusMessages, Radarr, q.Title, server.Paths),
-					IDs:         map[string]interface{}{"tmdbId": q.Movie.TmdbID, "imdbId": q.Movie.ImdbID, "downloadId": q.DownloadID},
+					IDs: map[string]interface{}{
+						"tmdbId":     q.Movie.TmdbID,
+						"imdbId":     q.Movie.ImdbID,
+						"downloadId": q.DownloadID,
+					},
 				})
 
 				fallthrough

--- a/pkg/unpackerr/start.go
+++ b/pkg/unpackerr/start.go
@@ -193,7 +193,7 @@ func (u *Unpackerr) Run() {
 
 // validateConfig makes sure config file values are ok. Returns file and dir modes.
 func (u *Unpackerr) validateConfig() (uint64, uint64) {
-	if u.DeleteDelay.Duration < minimumDeleteDelay {
+	if u.DeleteDelay.Duration >= 0 && u.DeleteDelay.Duration < minimumDeleteDelay {
 		u.DeleteDelay.Duration = minimumDeleteDelay
 	}
 


### PR DESCRIPTION
Closes #83 and closes #86.

Moves `delete_delay` from main app struct into each sub-app struct, so it can be configured independently. Also adds `delete_orig` so you can choose to delete original files upon successful extraction. I don't recommend set this value to true, but a NZB user requested it.

**Deprecates global `delete_after` and `timeout` variables.** 