### PR TITLE
Add discord and slack direct webhook support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,11 +141,16 @@ Works great with [notifiarr.com](https://notifiarr.com). You can use
 |---|---|---|
 webhook.url|`UN_WEBHOOK_0_URL`|No Default; URL to send POST webhook to|
 webhook.name|`UN_WEBHOOK_0_NAME`|Defaults to URL; provide an optional name to hide the URL in logs|
+webhook.nickname|`UN_WEBHOOK_0_NICKNAME`|`Unpackerr` / Passed into templates for discord.com and slack.com webhooks|
+webhook.channel|`UN_WEBHOOK_0_CHANNEL`|`""` / Passed into templates for slack.com webhooks|
 webhook.timeout|`UN_WEBHOOK_0_TIMEOUT`|Defaults to global timeout, usually `10s`|
 webhook.silent|`UN_WEBHOOK_0_SILENT`|`false` / Hide successful POSTs from logs|
 webhook.ignore_ssl|`UN_WEBHOOK_0_IGNORE_SSL`|`false` / Ignore invalid SSL certificates|
 webhook.exclude|`UN_WEBHOOK_0_EXCLUDE`|`[]` / List of apps to exclude: radarr, sonarr, folders, etc|
 webhook.events|`UN_WEBHOOK_0_EVENTS`|`[0]` / List of event IDs to send (shown below)|
+webhook.template_path|`UN_WEBHOOK_0_TEMPLATE_PATH`|`""` / Instead of internal template, provide your own|
+webhook.content_type|`UN_WEBHOOK_0_CONTENT_TYPE`|`application/json` / Content-Type header sent to webhook|
+
 
 Event IDs (not all of these are used in webhooks): `0` = all,
 `1` = queued, `2` = extracting, `3` = extract failed, `4` = extracted,

--- a/examples/MANUAL.md
+++ b/examples/MANUAL.md
@@ -1,4 +1,4 @@
-unpackerr(1) -- Utility Unpack compressed files for importing by Sonarr and Radarr.
+unpackerr(1) -- Unpack compressed files for importing by Starr applications.
 ===
 
 SYNOPSIS
@@ -30,6 +30,9 @@ OPTIONS
         This sends a webhook of the type specified then exits. This is only
         for testing and development. This requires a valid webhook configured
         in a config file or from environment variables.
+        Event IDs (not all of these are used in webhooks): 0 = all
+        1 = queued, 2 = extracting, 3 = extract failed, 4 = extracted
+        5 = imported, 6 = deleting, 7 = delete failed, 8 = deleted
 
     -v, --version
         Display version and exit.

--- a/examples/unpackerr.conf.example
+++ b/examples/unpackerr.conf.example
@@ -54,19 +54,22 @@ dir_mode = "0755"
 ### Webhooks ###
 ################
 # Sends a webhook when an extraction starts and again when it finishes.
-# Created to integrate with notifiarr.com. Also works with Discord.com webhooks.
-# Can possibly be used with other services. Don't forget to uncomment [[webhook]].
+# Created to integrate with notifiarr.com. Also works natively with Discord.com and Slack.com webhooks.
+# Can possibly be used with other services by providing a custom template_path.
+###### Don't forget to uncomment [[webhook]] and url at a minimum !!!!
 #[[webhook]]
 #  url    = "https://discordnotifier.com/notifier.php?api=abcdef-ghijklmn-op"
-#  name   = ""    # Set this to hide the URL in logs. Also used as Discord Username w/ Discord.com hook.
+#  name   = ""    # Set this to hide the URL in logs.
 #  silent = false # do not log success (less log spam)
 #  events = [0]   # list of event ids to include, 0 == all.
 ## Advanced Optional Webhook Configuration
+#  nickname      = ""    # Passed into templates. Used in Discord and Slack templates as bot name.
+#  channel       = ""    # Passed into templates. Used in Slack templates for destination channel.
 #  exclude       = []    # list of apps to exclude, ie. ["radarr", "lidarr"]
 #  template_path = ""    # Override internal webhook template for discord.com or other hooks.
 #  ignore_ssl    = false # Set this to true to ignore the SSL certificate on the server.
 #  timeout       = "10s" # You can adjust how long to wait for a server response.
-#  content_type  = "application/json" # If your custom webhook uses another MIME type, set this.
+#  content_type  = "application/json" # If your custom template uses another MIME type, set this.
 
 ################
 ### Episodes ###

--- a/examples/unpackerr.conf.example
+++ b/examples/unpackerr.conf.example
@@ -1,5 +1,6 @@
 ##      Unpackerr Example Configuration File      ##
 ## The following values are application defaults. ##
+## Environment Variables may override all values. ##
 ####################################################
 
 # [true/false] Turn on debug messages in the output. Do not wrap this in quotes.
@@ -53,14 +54,19 @@ dir_mode = "0755"
 ### Webhooks ###
 ################
 # Sends a webhook when an extraction starts and again when it finishes.
-# Created to integrate with discordnotifier.com.
+# Created to integrate with notifiarr.com. Also works with Discord.com webhooks.
 # Can possibly be used with other services. Don't forget to uncomment [[webhook]].
 #[[webhook]]
-#  url        = "https://discordnotifier.com/notifier.php?api=abcdef-ghijklmn-op"
-#  name       = ""    # Set this to hide the URL in logs.
-#  silent     = false # do not log success (less log spam)
-#  events     = [0]   # list of event ids to include, 0 == all.
-#  exclude    = []    # list of apps to exclude, ie. ["radarr", "lidarr"]
+#  url    = "https://discordnotifier.com/notifier.php?api=abcdef-ghijklmn-op"
+#  name   = ""    # Set this to hide the URL in logs. Also used as Discord Username w/ Discord.com hook.
+#  silent = false # do not log success (less log spam)
+#  events = [0]   # list of event ids to include, 0 == all.
+## Advanced Optional Webhook Configuration
+#  exclude       = []    # list of apps to exclude, ie. ["radarr", "lidarr"]
+#  template_path = ""    # Override internal webhook template for discord.com or other hooks.
+#  ignore_ssl    = false # Set this to true to ignore the SSL certificate on the server.
+#  timeout       = "10s" # You can adjust how long to wait for a server response.
+#  content_type  = "application/json" # If your custom webhook uses another MIME type, set this.
 
 ################
 ### Episodes ###

--- a/pkg/unpackerr/folder.go
+++ b/pkg/unpackerr/folder.go
@@ -340,6 +340,7 @@ func (u *Unpackerr) updateQueueStatus(data *newStatus) *Extract {
 			App:     "Unknown",
 			Status:  QUEUED,
 			Updated: time.Now(),
+			IDs:     map[string]interface{}{"title": data.Name}, // required or webhook may break.
 		}
 		u.sendWebhooks(u.Map[data.Name])
 

--- a/pkg/unpackerr/folder.go
+++ b/pkg/unpackerr/folder.go
@@ -337,7 +337,7 @@ func (u *Unpackerr) updateQueueStatus(data *newStatus) *Extract {
 		// Arr apps do not land here. They create their own queued items in u.Map.
 		u.Map[data.Name] = &Extract{
 			Path:    data.Name,
-			App:     "Unknown",
+			App:     "Folder",
 			Status:  QUEUED,
 			Updated: time.Now(),
 			IDs:     map[string]interface{}{"title": data.Name}, // required or webhook may break.

--- a/pkg/unpackerr/lidarr.go
+++ b/pkg/unpackerr/lidarr.go
@@ -110,7 +110,12 @@ func (u *Unpackerr) checkLidarrQueue() {
 					DeleteOrig:  server.DeleteOrig,
 					DeleteDelay: server.DeleteDelay.Duration,
 					Path:        u.getDownloadPath(q.StatusMessages, Lidarr, q.Title, server.Paths),
-					IDs:         map[string]interface{}{"artistId": q.ArtistID, "albumId": q.AlbumID, "downloadId": q.DownloadID},
+					IDs: map[string]interface{}{
+						"title":      q.Title,
+						"artistId":   q.ArtistID,
+						"albumId":    q.AlbumID,
+						"downloadId": q.DownloadID,
+					},
 				})
 
 				fallthrough

--- a/pkg/unpackerr/radarr.go
+++ b/pkg/unpackerr/radarr.go
@@ -96,18 +96,21 @@ func (u *Unpackerr) checkRadarrQueue() {
 			case ok && x.Status == EXTRACTED && u.isComplete(q.Status, q.Protocol, server.Protocols):
 				u.Debugf("%s (%s): Item Waiting for Import (%s): %v", Radarr, server.URL, q.Protocol, q.Title)
 			case (!ok || x.Status < QUEUED) && u.isComplete(q.Status, q.Protocol, server.Protocols):
-				u.handleCompletedDownload(q.Title, &Extract{
+				x := &Extract{
 					App:         Radarr,
 					DeleteOrig:  server.DeleteOrig,
 					DeleteDelay: server.DeleteDelay.Duration,
 					Path:        u.getDownloadPath(q.StatusMessages, Radarr, q.Title, server.Paths),
-					IDs: map[string]interface{}{
-						"title":      q.Movie.Title,
-						"tmdbId":     q.Movie.TmdbID,
-						"imdbId":     q.Movie.ImdbID,
-						"downloadId": q.DownloadID,
-					},
-				})
+					IDs:         map[string]interface{}{"downloadId": q.DownloadID, "title": q.Title},
+				}
+
+				if q.Movie != nil {
+					x.IDs["title"] = q.Movie.Title
+					x.IDs["tmdbId"] = q.Movie.TmdbID
+					x.IDs["imdbId"] = q.Movie.ImdbID
+				}
+
+				u.handleCompletedDownload(q.Title, x)
 
 				fallthrough
 			default:

--- a/pkg/unpackerr/radarr.go
+++ b/pkg/unpackerr/radarr.go
@@ -102,6 +102,7 @@ func (u *Unpackerr) checkRadarrQueue() {
 					DeleteDelay: server.DeleteDelay.Duration,
 					Path:        u.getDownloadPath(q.StatusMessages, Radarr, q.Title, server.Paths),
 					IDs: map[string]interface{}{
+						"title":      q.Movie.Title,
 						"tmdbId":     q.Movie.TmdbID,
 						"imdbId":     q.Movie.ImdbID,
 						"downloadId": q.DownloadID,

--- a/pkg/unpackerr/readarr.go
+++ b/pkg/unpackerr/readarr.go
@@ -109,7 +109,12 @@ func (u *Unpackerr) checkReadarrQueue() {
 					DeleteOrig:  server.DeleteOrig,
 					DeleteDelay: server.DeleteDelay.Duration,
 					Path:        u.getDownloadPath(q.StatusMessages, Readarr, q.Title, server.Paths),
-					IDs:         map[string]interface{}{"authorId": q.AuthorID, "bookId": q.BookID, "downloadId": q.DownloadID},
+					IDs: map[string]interface{}{
+						"title":      q.Title,
+						"authorId":   q.AuthorID,
+						"bookId":     q.BookID,
+						"downloadId": q.DownloadID,
+					},
 				})
 
 				fallthrough

--- a/pkg/unpackerr/sonarr.go
+++ b/pkg/unpackerr/sonarr.go
@@ -102,8 +102,13 @@ func (u *Unpackerr) checkSonarrQueue() {
 					DeleteDelay: server.DeleteDelay.Duration,
 					Path:        u.getDownloadPath(q.StatusMessages, Sonarr, q.Title, server.Paths),
 					IDs: map[string]interface{}{
-						"tvdbId": q.Series.TvdbID, "imdbId": q.Series.ImdbID, "downloadId": q.DownloadID,
-						"seriesId": q.Episode.SeriesID, "tvRageId": q.Series.TvRageID, "tvMazeId": q.Series.TvMazeID,
+						"title":      q.Title,
+						"tvdbId":     q.Series.TvdbID,
+						"imdbId":     q.Series.ImdbID,
+						"downloadId": q.DownloadID,
+						"seriesId":   q.Episode.SeriesID,
+						"tvRageId":   q.Series.TvRageID,
+						"tvMazeId":   q.Series.TvMazeID,
 					},
 				})
 

--- a/pkg/unpackerr/webhook.go
+++ b/pkg/unpackerr/webhook.go
@@ -69,7 +69,7 @@ func (u *Unpackerr) sendWebhooks(i *Extract) {
 			Start:    i.Resp.Started,
 			Output:   i.Resp.Output,
 			Bytes:    i.Resp.Size,
-			Elapsed:  i.Resp.Elapsed.Seconds(),
+			Elapsed:  cnfg.Duration{Duration: i.Resp.Elapsed},
 		}
 
 		if i.Resp.Error != nil {

--- a/pkg/unpackerr/webhook_samples.go
+++ b/pkg/unpackerr/webhook_samples.go
@@ -15,10 +15,11 @@ func (u *Unpackerr) sampleWebhook(e ExtractStatus) error {
 		return ErrInvalidStatus
 	}
 
-	payload := &NotifiarrPayload{
+	payload := &WebhookPayload{
 		App:  Sonarr,
 		Path: "/this/is/the/extraction/path",
 		IDs: map[string]interface{}{
+			"title":      "Some Cool Movie Name Here",
 			"downloadId": "some-id-goes-here",
 			"otherId":    "another-id-here-like-imdb",
 		},
@@ -45,7 +46,7 @@ func (u *Unpackerr) sampleWebhook(e ExtractStatus) error {
 	if e != EXTRACTING && e != EXTRACTED && e != EXTRACTFAILED {
 		payload.Data = nil
 	} else {
-		payload.Data.Bytes = 1234567
+		payload.Data.Bytes = 1234567009
 	}
 
 	if e == QUEUED {

--- a/pkg/unpackerr/webhook_samples.go
+++ b/pkg/unpackerr/webhook_samples.go
@@ -15,7 +15,7 @@ func (u *Unpackerr) sampleWebhook(e ExtractStatus) error {
 		return ErrInvalidStatus
 	}
 
-	payload := &WebhookPayload{
+	payload := &NotifiarrPayload{
 		App:  Sonarr,
 		Path: "/this/is/the/extraction/path",
 		IDs: map[string]interface{}{

--- a/pkg/unpackerr/webhook_samples.go
+++ b/pkg/unpackerr/webhook_samples.go
@@ -18,10 +18,10 @@ func (u *Unpackerr) sampleWebhook(e ExtractStatus) error {
 	}
 
 	payload := &WebhookPayload{
-		App:  Sonarr,
-		Path: "/this/is/the/extraction-path/Some.Cool.Movie.Name.Here",
+		App:  "Starr",
+		Path: "/this/is/a/path",
 		IDs: map[string]interface{}{
-			"title":      "Some Cool Movie Name Here",
+			"title":      "Some Cool Title Name Here",
 			"downloadId": fmt.Sprintf("some-id-goes-here-%d", time.Now().Unix()),
 			"otherId":    "another-id-here-like-imdb",
 		},

--- a/pkg/unpackerr/webhook_samples.go
+++ b/pkg/unpackerr/webhook_samples.go
@@ -1,9 +1,11 @@
 package unpackerr
 
 import (
+	"fmt"
 	"runtime"
 	"time"
 
+	"golift.io/cnfg"
 	"golift.io/version"
 	"golift.io/xtractr"
 )
@@ -17,10 +19,10 @@ func (u *Unpackerr) sampleWebhook(e ExtractStatus) error {
 
 	payload := &WebhookPayload{
 		App:  Sonarr,
-		Path: "/this/is/the/extraction/path",
+		Path: "/this/is/the/extraction-path/Some.Cool.Movie.Name.Here",
 		IDs: map[string]interface{}{
 			"title":      "Some Cool Movie Name Here",
-			"downloadId": "some-id-goes-here",
+			"downloadId": fmt.Sprintf("some-id-goes-here-%d", time.Now().Unix()),
 			"otherId":    "another-id-here-like-imdb",
 		},
 		Time:     time.Now(),
@@ -34,12 +36,12 @@ func (u *Unpackerr) sampleWebhook(e ExtractStatus) error {
 		Event:    e,
 		Data: &XtractPayload{
 			Start:    version.Started,
-			Elapsed:  time.Since(version.Started).Seconds(),
-			Archives: []string{"/this/is/the/extraction/path/archive.rar"},
+			Elapsed:  cnfg.Duration{Duration: time.Since(version.Started)},
+			Archives: []string{"/this/is/the/extraction/path/archive.rar", "/this/is/the/extraction/path/archive.sub.rar"},
 			Error:    "",
 			Output:   "/this/is/the/extraction/path_unpackerred",
 			Bytes:    0,
-			Files:    []string{"/this/is/the/extraction/path/file.mkv"},
+			Files:    []string{"/this/is/the/extraction/path/file.mkv", "/this/is/the/extraction/path/file.sub"},
 		},
 	}
 

--- a/pkg/unpackerr/webhooks_templates.go
+++ b/pkg/unpackerr/webhooks_templates.go
@@ -1,0 +1,142 @@
+package unpackerr
+
+import (
+	"fmt"
+	"html/template"
+	"strings"
+	"time"
+)
+
+// WebhookPayload defines the data sent to notifarr.com (and other) webhooks.
+type WebhookPayload struct {
+	Path  string                 `json:"path"`                // Path for the extracted item.
+	App   string                 `json:"app"`                 // Application Triggering Event
+	IDs   map[string]interface{} `json:"ids,omitempty"`       // Arbitrary IDs from each app.
+	Event ExtractStatus          `json:"unpackerr_eventtype"` // The type of the event.
+	Time  time.Time              `json:"time"`                // Time of this event.
+	Data  *XtractPayload         `json:"data,omitempty"`      // Payload from extraction process.
+	// Application Metadata.
+	Go       string    `json:"go_version"` // Version of go compiled with
+	OS       string    `json:"os"`         // Operating system: linux, windows, darwin
+	Arch     string    `json:"arch"`       // Architecture: amd64, armhf
+	Version  string    `json:"version"`    // Application Version
+	Revision string    `json:"revision"`   // Application Revision
+	Branch   string    `json:"branch"`     // Branch built from.
+	Started  time.Time `json:"started"`    // App start time.
+}
+
+// XtractPayload is a rewrite of xtractr.Response.
+type XtractPayload struct {
+	Error    string    `json:"error,omitempty"`      // error only during extractfailed
+	Archives []string  `json:"archives,omitempty"`   // list of all archive files extracted
+	Files    []string  `json:"files,omitempty"`      // list of all files extracted
+	Start    time.Time `json:"start,omitempty"`      // start time of extraction
+	Output   string    `json:"tmp_folder,omitempty"` // temporary items folder
+	Bytes    int64     `json:"bytes,omitempty"`      // Bytes written
+	Elapsed  float64   `json:"elapsed,omitempty"`    // Duration in seconds
+}
+
+// WebhookTemplateNotifiarr is the default template
+// when not using discord.com (below), or a custom template file.
+const WebhookTemplateNotifiarr = `{
+  "path": "{{.Path}}",
+  "app": "{{.App}}",
+  "ids": {
+    {{$s := separator ",\n"}}{{range $key, $value := .IDs}}{{call $s}}"{{$key}}": "{{$value}}"{{end}}
+  },
+  "unpackerr_eventtype": "{{.Event}}",
+  "time": "{{.Time}}",
+{{ if .Data }}    "data": {
+    "error": "{{.Data.Error}}",
+    "archives": [{{$s := separator ","}}{{range $index, $value := .Data.Archives}}{{call $s}}"{{$value}}"{{end}}],
+    "files": [{{$s := separator ","}}{{range $index, $value := .Data.Files}}{{call $s}}"{{$value}}"{{end}}],
+    "start": "{{.Data.Start}}",
+    "tmp_folder": "{{.Data.Output}}",
+    "bytes": "{{.Data.Bytes}}",
+    "elapsed": "{{.Data.Elapsed}}"
+    },
+{{ end }}    "go_version": "{{.Go}}",
+  "os": "{{.OS}}",
+  "arch": "{{.Arch}}",
+  "version": "{{.Version}}",
+  "revision": "{{.Revision}}",
+  "branch": "{{.Branch}}",
+  "started": "{{.Started}}"
+}
+`
+
+// WebhookTemplateDiscord is used when sending a webhook to discord.com.
+const WebhookTemplateDiscord = `{
+  "username": "{{name}}",
+  "avatar_url": "https://raw.githubusercontent.com/wiki/davidnewhall/unpackerr/images/logo.png",
+  "embeds": [
+    {
+     "title": "{{index .IDs "title"}}",
+     "author": {
+       "name": "Unpackerr: {{.Event.Desc}}",
+       "icon_url": "https://raw.githubusercontent.com/wiki/davidnewhall/unpackerr/images/logo.png"
+     },
+     "fields": [
+       {"name": "**Path**", "value": "{{.Path}}", "inline": false},
+       {"name": "**App**", "value": "{{.App}}", "inline": true},
+       {"name": "**Elapsed**", "value": "{{since .Started}}", "inline": true}{{ if .Data }},
+       {"name": "**Size**", "value": "{{humanbytes .Data.Bytes}}", "inline": true}{{- if .Data.Error }},
+       {"name": "**Error**", "value": "{{.Data.Error}}", "inline": false}{{ end }}{{ end }}
+     ]
+    }
+  ]
+}
+`
+const byteUnit = 1024
+
+// Template returns a template specific to this webhook.
+func (w *WebhookConfig) Template() (*template.Template, error) {
+	separator := func(s string) func() string {
+		var i bool
+
+		return func() string {
+			if !i {
+				i = true
+				return ""
+			}
+
+			return s
+		}
+	}
+
+	humanbytes := func(size int64) string {
+		// This is from https://yourbasic.org/golang/formatting-byte-size-to-human-readable-format/
+		// This func converts an int to a human readable byte string.
+		if size < byteUnit {
+			return fmt.Sprintf("%dB", size)
+		}
+
+		div, exp := int64(byteUnit), 0
+
+		for n := size / byteUnit; n >= byteUnit; n /= byteUnit {
+			div *= byteUnit
+			exp++
+		}
+
+		return fmt.Sprintf("%.1f%ciB", float64(size)/float64(div), "KMGTPE"[exp])
+	}
+
+	template := template.New("payload").Funcs(template.FuncMap{
+		"name":       func() string { return w.nickname },
+		"separator":  separator,
+		"humanbytes": humanbytes,
+		"since":      time.Since,
+	})
+
+	// Figure out which template to use based on URL or template_path.
+	switch url := strings.ToLower(w.URL); {
+	default:
+		fallthrough
+	case strings.Contains(url, "discordnotifier.com") || strings.Contains(url, "notifiarr.com"):
+		return template.Parse(WebhookTemplateNotifiarr)
+	case w.TmplPath != "":
+		return template.ParseFiles(w.TmplPath)
+	case strings.Contains(url, "discord.com"):
+		return template.Parse(WebhookTemplateDiscord)
+	}
+}

--- a/pkg/unpackerr/webhooks_templates.go
+++ b/pkg/unpackerr/webhooks_templates.go
@@ -79,14 +79,14 @@ const WebhookTemplateDiscord = `{
        "icon_url": "https://raw.githubusercontent.com/wiki/davidnewhall/unpackerr/images/logo.png"
      },
      "fields": [
-       {"name": "**Path**", "value": "{{.Path}}", "inline": false},
-       {"name": "**Version**", "value": "{{.Version}}-{{.Revision}}", "inline": true},
-       {"name": "**App**", "value": "{{.App}}", "inline": true}{{ if .Data }},
-       {"name": "**Elapsed**", "value": "{{.Data.Elapsed}}", "inline": true},
-       {"name": "**Archives**", "value": "{{len .Data.Archives}}", "inline": true},
-       {"name": "**Files**", "value": "{{len .Data.Files}}", "inline": true},
-       {"name": "**Size**", "value": "{{humanbytes .Data.Bytes}}", "inline": true}{{- if .Data.Error }},
-       {"name": "**Error**", "value": "{{.Data.Error}}", "inline": false}{{ end }}{{ end }}
+       {"name": "Path", "value": "{{.Path}}", "inline": false},
+       {"name": "Version", "value": "{{.Version}}-{{.Revision}}", "inline": true},
+       {"name": "App", "value": "{{.App}}", "inline": true}{{ if .Data }},
+       {"name": "Elapsed", "value": "{{.Data.Elapsed}}", "inline": true},
+       {"name": "Archives", "value": "{{len .Data.Archives}}", "inline": true},
+       {"name": "Files", "value": "{{len .Data.Files}}", "inline": true},
+       {"name": "Size", "value": "{{humanbytes .Data.Bytes}}", "inline": true}{{- if .Data.Error }},
+       {"name": "Error", "value": "{{.Data.Error}}", "inline": false}{{ end }}{{ end }}
      ]
     }
   ]

--- a/settings.sh
+++ b/settings.sh
@@ -14,7 +14,7 @@ HBREPO="golift/homebrew-mugs"
 MAINT="David Newhall II <david at sleepers dot pro>"
 VENDOR="Go Lift"
 DESC="Extracts downloads so Radarr, Sonarr, Lidarr or Readarr may import them."
-GOLANGCI_LINT_ARGS="--enable-all -D dupl,nlreturn,exhaustivestruct"
+GOLANGCI_LINT_ARGS="--enable-all -D dupl,nlreturn,exhaustivestruct,cyclop"
 # Example must exist at examples/$CONFIG_FILE.example
 CONFIG_FILE="unpackerr.conf"
 LICENSE="MIT"


### PR DESCRIPTION
Closes #82 by adding support for sending Webhooks to discord directly. Also supports Slack natively. You can also pass in your own POST template and send Webhooks to anything you want.