### PR TITLE
Crash fix and Panic Logs fix

### DIFF
--- a/pkg/unpackerr/logs.go
+++ b/pkg/unpackerr/logs.go
@@ -188,6 +188,10 @@ func (u *Unpackerr) setupLogging() {
 		log.SetOutput(writer)
 	}
 
+	if u.rotatorr != nil && u.rotatorr.File != nil {
+		dupStderr(u.rotatorr.File)
+	}
+
 	u.Logger.Logger.SetOutput(writer)
 	u.postLogRotate("", "")
 }
@@ -198,7 +202,7 @@ func (u *Unpackerr) postLogRotate(_, newFile string) {
 	}
 
 	if u.rotatorr != nil && u.rotatorr.File != nil {
-		_ = dupFD2(u.rotatorr.File.Fd(), 2)
+		dupStderr(u.rotatorr.File)
 	}
 }
 

--- a/pkg/unpackerr/logs.go
+++ b/pkg/unpackerr/logs.go
@@ -188,10 +188,6 @@ func (u *Unpackerr) setupLogging() {
 		log.SetOutput(writer)
 	}
 
-	if u.rotatorr != nil && u.rotatorr.File != nil {
-		dupStderr(u.rotatorr.File)
-	}
-
 	u.Logger.Logger.SetOutput(writer)
 	u.postLogRotate("", "")
 }
@@ -202,7 +198,7 @@ func (u *Unpackerr) postLogRotate(_, newFile string) {
 	}
 
 	if u.rotatorr != nil && u.rotatorr.File != nil {
-		dupStderr(u.rotatorr.File)
+		redirectStderr(u.rotatorr.File) // Log panics.
 	}
 }
 

--- a/pkg/unpackerr/logs_linux.go
+++ b/pkg/unpackerr/logs_linux.go
@@ -1,11 +1,13 @@
 package unpackerr
 
+/* The purpose of this code is to log stderr (application panics) to a log file. */
+
 import (
 	"os"
 	"syscall"
 )
 
-func dupStderr(file *os.File) {
+func redirectStderr(file *os.File) {
 	os.Stderr = file
 	_ = syscall.Dup3(int(file.Fd()), syscall.Stderr, 0)
 }

--- a/pkg/unpackerr/logs_linux.go
+++ b/pkg/unpackerr/logs_linux.go
@@ -1,9 +1,11 @@
 package unpackerr
 
 import (
+	"os"
 	"syscall"
 )
 
-func dupFD2(oldfd uintptr, newfd uintptr) error {
-	return syscall.Dup3(int(oldfd), int(newfd), 0) //nolint:wrapcheck
+func dupStderr(file *os.File) {
+	os.Stderr = file
+	_ = syscall.Dup3(int(file.Fd()), syscall.Stderr, 0)
 }

--- a/pkg/unpackerr/logs_others.go
+++ b/pkg/unpackerr/logs_others.go
@@ -3,9 +3,11 @@
 package unpackerr
 
 import (
+	"os"
 	"syscall"
 )
 
-func dupFD2(oldfd uintptr, newfd uintptr) error {
-	return syscall.Dup2(int(oldfd), int(newfd)) //nolint:wrapcheck
+func dupStderr(file *os.File) {
+	os.Stderr = file
+	_ = syscall.Dup2(int(file.Fd()), syscall.Stderr)
 }

--- a/pkg/unpackerr/logs_others.go
+++ b/pkg/unpackerr/logs_others.go
@@ -2,12 +2,15 @@
 
 package unpackerr
 
+/* The purpose of this code is to log stderr (application panics) to a log file. */
+
 import (
 	"os"
 	"syscall"
 )
 
-func dupStderr(file *os.File) {
+func redirectStderr(file *os.File) {
 	os.Stderr = file
+	// This works on darwin and freebsd, maybe others.
 	_ = syscall.Dup2(int(file.Fd()), syscall.Stderr)
 }

--- a/pkg/unpackerr/logs_windows.go
+++ b/pkg/unpackerr/logs_windows.go
@@ -14,5 +14,8 @@ var (
 //nolint:errcheck
 func dupStderr(file *os.File) {
 	os.Stderr = file
-	syscall.Syscall(setHandle.Addr(), 2, file.Fd(), uintptr(syscall.Stderr), 0)
+	h := syscall.STD_ERROR_HANDLE
+	f := file.Fd()
+
+	syscall.Syscall(setHandle.Addr(), 2, uintptr(h), uintptr(f), 0)
 }

--- a/pkg/unpackerr/logs_windows.go
+++ b/pkg/unpackerr/logs_windows.go
@@ -1,5 +1,7 @@
 package unpackerr
 
+/* The purpose of this code is to log stderr (application panics) to a log file. */
+
 import (
 	"os"
 	"syscall"
@@ -12,10 +14,9 @@ var (
 )
 
 //nolint:errcheck
-func dupStderr(file *os.File) {
+func redirectStderr(file *os.File) {
 	os.Stderr = file
-	h := syscall.STD_ERROR_HANDLE
-	f := file.Fd()
+	stderr := syscall.STD_ERROR_HANDLE
 
-	syscall.Syscall(setHandle.Addr(), 2, uintptr(h), uintptr(f), 0)
+	syscall.Syscall(setHandle.Addr(), 2, uintptr(stderr), file.Fd(), 0)
 }

--- a/pkg/unpackerr/radarr.go
+++ b/pkg/unpackerr/radarr.go
@@ -113,6 +113,10 @@ func (u *Unpackerr) getRadarrQueue() {
 // checkRadarrQueue passes completed Radarr-queued downloads to the HandleCompleted method.
 func (u *Unpackerr) checkRadarrQueue() {
 	for _, server := range u.Radarr {
+		if server.Queue == nil {
+			continue
+		}
+
 		for _, q := range server.Queue.Records {
 			switch x, ok := u.Map[q.Title]; {
 			case ok && x.Status == EXTRACTED && u.isComplete(q.Status, q.Protocol, server.Protocols):

--- a/pkg/unpackerr/sonarr.go
+++ b/pkg/unpackerr/sonarr.go
@@ -113,6 +113,10 @@ func (u *Unpackerr) getSonarrQueue() {
 // checkSonarrQueue passes completed Sonarr-queued downloads to the HandleCompleted method.
 func (u *Unpackerr) checkSonarrQueue() {
 	for _, server := range u.Sonarr {
+		if server.Queue == nil {
+			continue
+		}
+
 		for _, q := range server.Queue.Records {
 			switch x, ok := u.Map[q.Title]; {
 			case ok && x.Status == EXTRACTED && u.isComplete(q.Status, q.Protocol, server.Protocols):

--- a/settings.sh
+++ b/settings.sh
@@ -14,7 +14,7 @@ HBREPO="golift/homebrew-mugs"
 MAINT="David Newhall II <david at sleepers dot pro>"
 VENDOR="Go Lift"
 DESC="Extracts downloads so Radarr, Sonarr, Lidarr or Readarr may import them."
-GOLANGCI_LINT_ARGS="--enable-all -D dupl,nlreturn,exhaustivestruct,cyclop,tagliatelle"
+GOLANGCI_LINT_ARGS="--enable-all -D dupl,nlreturn,exhaustivestruct,cyclop,tagliatelle,interfacer,scopelint,maligned,golint"
 # Example must exist at examples/$CONFIG_FILE.example
 CONFIG_FILE="unpackerr.conf"
 LICENSE="MIT"


### PR DESCRIPTION
This contribution fixes a crash/panic when Radarr or Sonarr are configured, but not properly responding. It also fixes a bug that prevented panic messages (stack traces) from being written to the log file.