### PR TITLE
Add pushover web hook template.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ Works great with [notifiarr.com](https://notifiarr.com). You can use
 webhook.url|`UN_WEBHOOK_0_URL`|No Default; URL to send POST webhook to|
 webhook.name|`UN_WEBHOOK_0_NAME`|Defaults to URL; provide an optional name to hide the URL in logs|
 webhook.nickname|`UN_WEBHOOK_0_NICKNAME`|`Unpackerr` / Passed into templates for telegram, discord and slack hooks|
-webhook.channel|`UN_WEBHOOK_0_CHANNEL`|`""` / Passed into templates for slack.com webhooks|
+webhook.channel|`UN_WEBHOOK_0_CHANNEL`|`""` / Passed into templates for slack.com/pushover webhooks|
+webhook.token|`UN_WEBHOOK_0_TOKEN`|`""` / Passed into templates for Pushover webhooks as `API_TOKEN`.|
 webhook.timeout|`UN_WEBHOOK_0_TIMEOUT`|Defaults to global timeout, usually `10s`|
 webhook.silent|`UN_WEBHOOK_0_SILENT`|`false` / Hide successful POSTs from logs|
 webhook.ignore_ssl|`UN_WEBHOOK_0_IGNORE_SSL`|`false` / Ignore invalid SSL certificates|
@@ -163,9 +164,9 @@ Event IDs (not all of these are used in webhooks): `0` = all,
 
 ###### Webhook Notes
 
-1. _`Nickname` should equal the `chat_id` value in Telegram webhooks._
-1. _`Channel` is used as destination channel for Slack. It's not used in others._
-1. _`Nickname` and `Channel` may be used as custom values in custom templates._
+1. _`Nickname` should equal the `chat_id` value in Telegram webhooks. It may be used as a device ID in Pushover._
+1. _`Channel` is used as destination channel for Slack, and as `USER_TOKEN` in Pushover. It's not used in others._
+1. _`Nickname`, `Token` and `Channel` may be used as custom values in custom templates._
 1. _`Name` is only used in logs, but it's also available as a template value as `{{name}}`._
 
 ##### Example Usage


### PR DESCRIPTION
This contribution adds a built-in template for sending pushover webhook messages.
```
[[webhook]]
  name    = "Pushover"
  url     = "https://api.pushover.net/1/messages.json"
  token   = "API_TOKEN"
  channel = "USER_TOKEN"
```