### PR TITLE
fix slack template error

### DIFF
--- a/pkg/unpackerr/webhooks_templates.go
+++ b/pkg/unpackerr/webhooks_templates.go
@@ -234,7 +234,7 @@ const WebhookTemplateSlack = `
           "text": "*Elapsed*\n{{.Data.Elapsed}}"
         }{{end}}{{end -}}
       ]
-    }{{if and (.Data .Data.Error)}},{
+    }{{if and .Data .Data.Error}},{
       "type": "section",
       "text": {
         "type": "mrkdwn",


### PR DESCRIPTION
Closes #231 by fixing the Slack web hook template.